### PR TITLE
client: Minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Installation:
 
 _In a separate shell:_
     
+    $ cd client
     $ npm install
-    $ bower install
-    $ ember serve
+    $ npm start
 
 Usage:
 ------

--- a/client/README.md
+++ b/client/README.md
@@ -22,7 +22,7 @@ You will need the following things properly installed on your computer.
 
 ## Running / Development
 
-* `ember serve`
+* `ember server`
 * Visit your app at [http://localhost:4200](http://localhost:4200).
 
 ### Code Generators

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
   },
   "repository": "",
   "scripts": {
+    "postinstall": "bower install",
     "build": "ember build",
     "start": "ember server",
     "test": "ember test"


### PR DESCRIPTION
- client: fixing sintax in npm start's script

- using postinstall script after npm install command

   users couldn't have bower or ember installed globally. To avoid this we can use
npm built-in scripts like `postinstall` and `start`